### PR TITLE
OTP compatibility and dialyzer issues

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,10 @@
-{erl_opts, [debug_info]}.
+{minimum_otp_vsn, "22.0"}.
+
+{erl_opts, [warnings_as_errors]}.
+
 {deps, []}.
+
+{xref_checks, [undefined_function_calls,undefined_functions,locals_not_used]}.
 
 {project_plugins, [rebar3_ex_doc, rebar3_hex]}.
 

--- a/src/thoas_decode.erl
+++ b/src/thoas_decode.erl
@@ -5,6 +5,8 @@
     {throw_error, 2}, {continue, 7}
 ]}]).
 
+-dialyzer(no_improper_lists).
+
 -export([decode/2]).
 
 % We use integers instead of atoms to take advantage of the jump table optimization

--- a/src/thoas_decode.erl
+++ b/src/thoas_decode.erl
@@ -15,6 +15,20 @@
 -define(key, 2).
 -define(object, 3).
 
+-if(?OTP_RELEASE =:= 22).
+convert_to_atom(Binary) ->
+    binary_to_atom(Binary, utf8).
+
+convert_to_existing_atom(Binary) ->
+    binary_to_existing_atom(Binary, utf8).
+-else.
+convert_to_atom(Binary) ->
+    binary_to_atom(Binary).
+
+convert_to_existing_atom(Binary) ->
+    binary_to_existing_atom(Binary).
+-endif.
+
 array(Rest, Input, Skip, Stack, StringDecode, KeyDecode) ->
     value(Rest, Input, Skip, [?array, [] | Stack], StringDecode, KeyDecode).
 
@@ -1091,12 +1105,12 @@ key_decode_function(Options) ->
 
 identity(Key) -> Key.
 
-to_atom(Key) when is_binary(Key) -> binary_to_atom(Key);
+to_atom(Key) when is_binary(Key) -> convert_to_atom(Key);
 to_atom(Key) -> Key.
 
 to_existing_atom(Key) when is_binary(Key) ->
     try
-        binary_to_existing_atom(Key)
+        convert_to_existing_atom(Key)
     catch
         error:badarg -> Key
     end;

--- a/test/thoas_encode_test.erl
+++ b/test/thoas_encode_test.erl
@@ -36,6 +36,7 @@ integer_test_() ->
         || {Input, Expected} <- Cases
     ].
 
+-if(?OTP_RELEASE >= 25).
 float_test_() ->
     Cases = [
         {0.0, <<"0.0">>},
@@ -49,6 +50,8 @@ float_test_() ->
         ?_assertEqual(Expected, float(Input))
         || {Input, Expected} <- Cases
     ].
+-endif.
+
 
 string_test_() ->
     Cases = [
@@ -122,10 +125,21 @@ encode_test_() ->
 types_test_() ->
     Cases =[
         {#{<<"date">> => {2023,8,7}}, <<"{\"date\":\"2023-08-07\"}">>},
-        {#{<<"datetime">> => {{2023,8,7},{19,2,24}}}, <<"{\"datetime\":\"2023-08-07T19:02:24Z\"}">>},
+        {#{<<"datetime">> => {{2023,8,7},{19,2,24}}}, <<"{\"datetime\":\"2023-08-07T19:02:24Z\"}">>}
+    ],
+    [
+        ?_assertEqual(Expected, iolist_to_binary(encode(Input, #{})))
+        || {Input, Expected} <- Cases
+    ].
+
+-if(?OTP_RELEASE >= 25).
+types_withfloat_test_() ->
+    Cases =[
         {#{<<"datetime">> => {{2023,8,7},{19,2,24.65432}}}, <<"{\"datetime\":\"2023-08-07T19:02:24.65432Z\"}">>}
     ],
     [
         ?_assertEqual(Expected, iolist_to_binary(encode(Input, #{})))
         || {Input, Expected} <- Cases
     ].
+-endif.
+    


### PR DESCRIPTION
There are two OTP compatibility issues:

- The `[short]` option on float_to_binary, is not available until OTP 25.  Without converting floats to-and-from may not return the same results.  As we don't include floats in JSON in Riak, we wrok around this for earlier versions, and disable the relevant tests.
- The `binary_to_atom/1` and `binary_to_existing_atom/1` are not available in OTP 22 - so the equivalent 2-arity function is used.  Again there is no conversion of atoms in Riak's use - and so this is not relevant.

The remaining issue is a large number of dialyzer warnings about improper lists.  See OTP discussion on this warning - https://github.com/erlang/otp/issues/5937.  I'm not sure of the relevance, so rather than attempt to "fix" the code, the decision here is to trust the code and disable the warning.